### PR TITLE
Fix airtable logging when credentials missing

### DIFF
--- a/airtable_logger.py
+++ b/airtable_logger.py
@@ -11,12 +11,16 @@ print("DEBUG - AIRTABLE_BASE_ID:", AIRTABLE_BASE_ID)
 print("DEBUG - AIRTABLE_TABLE_NAME:", AIRTABLE_TABLE_NAME)
 print("DEBUG - AIRTABLE_API_KEY starts with:", AIRTABLE_API_KEY[:4] if AIRTABLE_API_KEY else "None")
 
+airtable = None
 try:
     airtable = Airtable(AIRTABLE_BASE_ID, AIRTABLE_TABLE_NAME, AIRTABLE_API_KEY)
 except Exception as e:
     print("Airtable instantiation error:", e)
 
 def log_valuation(data):
+    if airtable is None:
+        print("Airtable not configured; skipping log")
+        return
     try:
         airtable.insert(data)
     except Exception as e:


### PR DESCRIPTION
## Summary
- avoid NameError if airtable credentials are missing
- log and skip logging when Airtable is not configured

## Testing
- `python -m py_compile airtable_logger.py epc_client.py airtable_to_dataframe.py train_model.py train_route.py training_prep.py mock_zoopla.py zoopla.py app.py`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4a597f48327aee59519706b728b