### PR TITLE
Fix predict API feature mismatch

### DIFF
--- a/predict_api.py
+++ b/predict_api.py
@@ -12,7 +12,15 @@ def predict():
         data = request.get_json(force=True)
         print("Received data:", data)
 
-        features = np.array([[data['bedrooms'], data['bathrooms'], data['sqft']]])
+        epc_map = {'A': 7, 'B': 6, 'C': 5, 'D': 4, 'E': 3, 'F': 2, 'G': 1}
+        epc_numeric = epc_map.get(str(data.get('epc_rating', '')).upper(), 0)
+
+        features = np.array([[
+            data['bedrooms'],
+            data['bathrooms'],
+            data['sqft'],
+            epc_numeric
+        ]])
         prediction = model.predict(features)
         print("Prediction:", prediction)
 


### PR DESCRIPTION
## Summary
- include EPC rating numeric conversion when forming feature vector

## Testing
- `python -m py_compile predict_api.py`
- `python train_model.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_6841365e3a9483279105daf33263da90